### PR TITLE
useRefs() hook

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -24,6 +24,7 @@
     - [usePlaybackState()](#useplaybackstate--)
     - [usePosition()](#useposition--)
     - [useQuality()](#usequality--)
+    - [useRefs()](#userefs--)
     - [useSubtitleTrack()](#usesubtitletrack--)
     - [useVolume()](#usevolume--)
   - [Events](#events-1)
@@ -246,6 +247,17 @@ const useQuality: () => [
 ];
 ```
 Get the available qualities, and any currently selected quality.
+
+#### useRefs()
+```ts
+import {useRefs} from "hls-hooks";
+
+const useRefs: () => [
+    videoElementRef?: RefObject<HTMLVideoElement>,
+    hlsRef?: RefObject<Hls|null>
+];
+```
+Get references to the current `<video>` element and the HLS.js `Hls` object.
 
 #### useSubtitleTrack()
 ```ts

--- a/src/hooks/use-refs.ts
+++ b/src/hooks/use-refs.ts
@@ -1,0 +1,14 @@
+import useHlsInternals from "./use-hls-internals";
+import {RefObject} from "react";
+import Hls from "hls.js";
+
+const useRefs = (): [
+    videoElementRef?: RefObject<HTMLVideoElement>,
+    hlsRef?: RefObject<Hls|null>
+] => {
+    const {hlsRef, videoElementRef} = useHlsInternals();
+
+    return [videoElementRef, hlsRef];
+};
+
+export default useRefs;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,9 @@ export {default as useIsPlaying} from "./hooks/use-is-playing";
 export {default as usePlaybackState} from "./hooks/use-playback-state";
 export {default as usePosition} from "./hooks/use-position";
 export {default as useQuality} from "./hooks/use-quality";
+export {default as useRefs} from "./hooks/use-refs";
 export {default as useSubtitleTrack} from "./hooks/use-subtitle-track";
 export {default as useVolume} from "./hooks/use-volume";
 
 export type {Level, MediaPlaylist} from "hls.js";
+


### PR DESCRIPTION
Expose the HLS.js Hls context and the reference to the <video> element.